### PR TITLE
nforsch/add pointcloud export

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ INFO:ukb.mesh:Created mesh data/ED_clipped.msh
 
 ![_](https://github.com/ComputationalPhysiology/ukb-atlas/blob/main/docs/_static/clipped.png)
 
+We can also export labelled point clouds directly from the atlas using the `points` command
+```
+$ ukb-atlas points data --mode -1 --std 1.5 --case both
+INFO:ukb.atlas:Generating points from /root/.ukb/UKBRVLV.h5
+INFO:ukb.atlas:Using mode -1 and std 1.5
+INFO:ukb.pointcloud:Saved data/ED_pointcloud.tsv
+INFO:ukb.pointcloud:Saved data/ES_pointcloud.tsv
+```
+This generates tab-separated files (`ED_pointcloud.tsv`, `ES_pointcloud.tsv`) with columns `x`, `y`, `z`, `label`, and `region` for each labelled point on the biventricular surface.
+
 ## Usage
 There are three main commands:
 1. `surf` - Extract surfaces from the atlas and save them in the specified directory as STL files

--- a/src/ukb/cli.py
+++ b/src/ukb/cli.py
@@ -4,7 +4,7 @@ from typing import Sequence
 import logging
 import argparse
 
-from . import surface, mesh, clip
+from . import surface, mesh, clip, pointcloud
 
 
 def get_parser() -> argparse.ArgumentParser:
@@ -37,6 +37,12 @@ def get_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     mesh.add_parser_arguments(mesh_parser)
+    points_parser = subparsers.add_parser(
+        "points",
+        help="Export labelled point clouds from the atlas",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    pointcloud.add_parser_arguments(points_parser)
 
     return parser
 
@@ -61,6 +67,8 @@ def dispatch(parser: argparse.ArgumentParser, argv: Sequence[str] | None = None)
         clip.main(**args)
     elif command == "mesh":
         mesh.main(**args)
+    elif command == "points":
+        pointcloud.main(**args)
     else:
         parser.error(f"Unknown command {command}")
     return 0

--- a/src/ukb/pointcloud.py
+++ b/src/ukb/pointcloud.py
@@ -152,6 +152,7 @@ def main(
         Suffix for the output files. By default ``".tsv"`` (tab-separated).
         Can be changed to ``".csv"`` (comma-separated).
     """
+    assert suffix in {".tsv", ".csv"}, "Suffix must be either .tsv or .csv"
     folder = Path(folder)
     folder.mkdir(exist_ok=True, parents=True)
 

--- a/src/ukb/pointcloud.py
+++ b/src/ukb/pointcloud.py
@@ -72,6 +72,12 @@ def add_parser_arguments(parser: ArgumentParser) -> None:
         default="ED",
         help="Case to export point cloud for.",
     )
+    parser.add_argument(
+        "--suffix",
+        type=str,
+        default=".tsv",
+        help='Suffix for the output files. By default ".tsv". Can be changed to ".csv".',
+    )
 
 
 def get_point_cloud(
@@ -118,11 +124,12 @@ def main(
     verbose: bool = False,
     cache_dir: Path = Path.home() / ".ukb",
     case: Literal["ED", "ES", "both"] = "ED",
+    suffix: str = ".tsv",
 ) -> None:
     """Export labelled point clouds from the UK Biobank atlas.
 
-    For each requested case (ED, ES, or both) writes one TSV file:
-    - ``{case}_pointcloud.tsv`` — tab-separated file with columns
+    For each requested case (ED, ES, or both) writes one file:
+    - ``{case}_pointcloud{suffix}`` - file with columns
       ``x``, ``y``, ``z``, ``label`` (integer), ``region`` (surface name).
 
     Parameters
@@ -141,6 +148,9 @@ def main(
         Directory where the atlas is cached / downloaded to.
     case : str
         Which cardiac phase(s) to export: ``"ED"``, ``"ES"``, or ``"both"``.
+    suffix : str
+        Suffix for the output files. By default ``".tsv"`` (tab-separated).
+        Can be changed to ``".csv"`` (comma-separated).
     """
     folder = Path(folder)
     folder.mkdir(exist_ok=True, parents=True)
@@ -166,9 +176,12 @@ def main(
     for c in cases:
         points, labels, label_names = get_point_cloud(getattr(pts, c))
 
-        out_path = folder / f"{c}_pointcloud.tsv"
+        out_path = folder / f"{c}_pointcloud{suffix}"
+        delimiter = "\t" if suffix == ".tsv" else ","
         with out_path.open("w") as f:
-            f.write("x\ty\tz\tlabel\tregion\n")
+            f.write(f"x{delimiter}y{delimiter}z{delimiter}label{delimiter}region\n")
             for (x, y, z), label in zip(points, labels):
-                f.write(f"{x}\t{y}\t{z}\t{label}\t{label_names[label]}\n")
+                f.write(
+                    f"{x}{delimiter}{y}{delimiter}{z}{delimiter}{label}{delimiter}{label_names[label]}\n"
+                )
         logger.info(f"Saved {out_path}")

--- a/src/ukb/pointcloud.py
+++ b/src/ukb/pointcloud.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import Literal
+
+from . import atlas
+from .surface import surfaces
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+def add_parser_arguments(parser: ArgumentParser) -> None:
+    parser.add_argument(
+        "folder",
+        type=Path,
+        help="Directory to save the generated point clouds.",
+    )
+    parser.add_argument(
+        "-a",
+        "--all",
+        action="store_true",
+        help=(
+            "Use the PCA atlas derived from all 4,329 subjects from the UK "
+            "Biobank Study. By default we use the PCA atlas derived from 630 healthy "
+            "reference subjects from the UK Biobank Study"
+        ),
+    )
+    parser.add_argument(
+        "-m",
+        "--mode",
+        type=int,
+        default=-1,
+        help=(
+            "Mode to generate points from. If -1, generate points from the mean "
+            "shape. If between 0 and the number of modes, generate points from "
+            "the specified mode. By default -1"
+        ),
+    )
+    parser.add_argument(
+        "-s",
+        "--std",
+        type=float,
+        default=1.5,
+        help="Standard deviation to scale the mode by. By default 1.5",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Print verbose output.",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=os.environ.get("UKB_CACHE_DIR", Path.home() / ".ukb"),
+        help=(
+            "Directory to save the downloaded atlas. "
+            "Can also be set with the UKB_CACHE_DIR environment variable. "
+            "By default ~/.ukb"
+        ),
+    )
+    parser.add_argument(
+        "-c",
+        "--case",
+        choices=["ED", "ES", "both"],
+        default="ED",
+        help="Case to export point cloud for.",
+    )
+
+
+def get_point_cloud(
+    points: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, dict[int, str]]:
+    """Return a labelled point cloud from a post-deletion points array.
+
+    Parameters
+    ----------
+    points:
+        Array of shape ``(N, 3)`` as returned by
+        :func:`ukb.atlas.generate_points` (ED or ES field).
+
+    Returns
+    -------
+    points : np.ndarray, shape (M, 3)
+        Labelled points only (unlabelled nodes dropped).  ``M <= N``.
+    labels : np.ndarray, shape (M,), dtype int
+        Integer label for each point.  Labels start at ``1``; there is no
+        ``0`` entry in the returned array.
+        When a node falls in multiple surface regions the last entry in
+        :data:`surfaces` (in iteration order) wins.
+    label_names : dict[int, str]
+        Mapping from integer label to surface name.
+    """
+    labels = np.zeros(len(points), dtype=int)
+    label_names: dict[int, str] = {}
+
+    for i, (name, surface) in enumerate(surfaces.items(), start=1):
+        label_names[i] = name
+        idx = surface.post_deletion_vertex_indices
+        idx = idx[idx < len(points)]
+        labels[idx] = i
+
+    keep = labels != 0
+    return points[keep], labels[keep], label_names
+
+
+def main(
+    folder: Path,
+    all: bool = False,
+    mode: int = -1,
+    std: float = 1.5,
+    verbose: bool = False,
+    cache_dir: Path = Path.home() / ".ukb",
+    case: Literal["ED", "ES", "both"] = "ED",
+) -> None:
+    """Export labelled point clouds from the UK Biobank atlas.
+
+    For each requested case (ED, ES, or both) writes one TSV file:
+    - ``{case}_pointcloud.tsv`` — tab-separated file with columns
+      ``x``, ``y``, ``z``, ``label`` (integer), ``region`` (surface name).
+
+    Parameters
+    ----------
+    folder : Path
+        Directory to save the generated point clouds.
+    all : bool
+        If true, use the PCA atlas derived from all 4,329 subjects.
+    mode : int
+        PCA mode to generate points from. -1 = mean shape.
+    std : float
+        Standard deviation to scale the mode by.
+    verbose : bool
+        If true, print verbose output.
+    cache_dir : Path
+        Directory where the atlas is cached / downloaded to.
+    case : str
+        Which cardiac phase(s) to export: ``"ED"``, ``"ES"``, or ``"both"``.
+    """
+    folder = Path(folder)
+    folder.mkdir(exist_ok=True, parents=True)
+
+    params = {
+        "folder": str(folder),
+        "all": all,
+        "mode": mode,
+        "std": std,
+        "verbose": verbose,
+        "cache_dir": str(cache_dir),
+        "case": case,
+    }
+    (folder / "parameters.json").write_text(json.dumps(params, indent=4, sort_keys=True))
+
+    cache_dir = Path(cache_dir)
+    cache_dir.mkdir(exist_ok=True, parents=True)
+    filename = atlas.download_atlas(cache_dir, all=all)
+    pts = atlas.generate_points(filename=filename, mode=mode, std=std)
+
+    cases = ["ED", "ES"] if case == "both" else [case]
+
+    for c in cases:
+        points, labels, label_names = get_point_cloud(getattr(pts, c))
+
+        out_path = folder / f"{c}_pointcloud.tsv"
+        with out_path.open("w") as f:
+            f.write("x\ty\tz\tlabel\tregion\n")
+            for (x, y, z), label in zip(points, labels):
+                f.write(f"{x}\t{y}\t{z}\t{label}\t{label_names[label]}\n")
+        logger.info(f"Saved {out_path}")

--- a/src/ukb/surface.py
+++ b/src/ukb/surface.py
@@ -224,6 +224,25 @@ class Surface(NamedTuple):
         return np.concatenate([np.arange(start, end) for start, end in self.vertex_range])
 
     @property
+    def post_deletion_vertex_indices(self) -> np.ndarray:
+        """Vertex indices remapped into the post-deletion point array.
+
+        ``generate_points`` removes ``atlas.unwanted_nodes`` from the raw
+        coordinate array with ``np.delete``, which shifts every node whose
+        original index is greater than a deleted node.  ``vertex_range`` stores
+        *original* indices, so this property converts them to the indices that
+        are valid in the array returned by ``generate_points``.
+
+        Nodes that are themselves in ``unwanted_nodes`` are excluded.
+        """
+        original = self.vertex_indices
+        unwanted_sorted = np.array(sorted(atlas.unwanted_nodes))
+        mask = ~np.isin(original, atlas.unwanted_nodes)
+        valid = original[mask]
+        shifts = np.searchsorted(unwanted_sorted, valid, side="left")
+        return valid - shifts
+
+    @property
     def face_indices(self):
         return np.concatenate([np.arange(start, end) for start, end in self.face_range])
 

--- a/tests/test_ukb.py
+++ b/tests/test_ukb.py
@@ -138,3 +138,29 @@ def test_generate_surfaces_non_mean_healthy(tmp_path, atlas_path):
         for case in ["ED", "ES"]:
             path = tmp_path / f"{name}_{case}.stl"
             assert path.exists()
+
+
+@pytest.mark.parametrize("case", ["ED", "ES", "both"])
+@pytest.mark.parametrize("suffix", [".tsv", ".csv"])
+def test_pointcloud(tmp_path, atlas_path, suffix, case):
+    ukb.cli.main(
+        [
+            "points",
+            str(tmp_path),
+            "--mode",
+            "-1",
+            "--std",
+            "0.0",
+            "--case",
+            case,
+            "--cache-dir",
+            str(atlas_path.parent),
+            "--suffix",
+            suffix,
+        ]
+    )
+
+    cases = ["ED", "ES"] if case == "both" else [case]
+    for c in cases:
+        path = tmp_path / f"{c}_pointcloud{suffix}"
+        assert path.exists()


### PR DESCRIPTION
Add functionality to export atlas point cloud data. Stores tsv file with x, y, z, label, and label_name.

Usage
`$ ukb-atlas points data --mode -1 --std 1.5 --case both`

Closes #27 